### PR TITLE
MED-48: Attempt to fix AJP Connector error

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -88,7 +88,7 @@
         -->
 
         <!-- Define an AJP 1.3 Connector on port 8009 -->
-        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="::1" secretRequired="false"/>
+        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" address="0.0.0.0" secretRequired="false"/>
 
 
         <!-- An Engine represents the entry point (within Catalina) that processes


### PR DESCRIPTION
Error from SCORM Engine logs:
```
17-Jan-2024 22:24:07.319 SEVERE [main] org.apache.catalina.util.LifecycleBase.handleSubClassException Failed to initialize component [Connector["ajp-nio-0:0:0:0:0:0:0:1-8009"]]
	org.apache.catalina.LifecycleException: Protocol handler initialization failed
		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1011)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:127)
		at org.apache.catalina.core.StandardService.initInternal(StandardService.java:554)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:127)
		at org.apache.catalina.core.StandardServer.initInternal(StandardServer.java:1039)
		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:127)
		at org.apache.catalina.startup.Catalina.load(Catalina.java:724)
		at org.apache.catalina.startup.Catalina.load(Catalina.java:746)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
		at java.base/java.lang.reflect.Method.invoke(Unknown Source)
		at org.apache.catalina.startup.Bootstrap.load(Bootstrap.java:307)
		at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:477)
	Caused by: java.nio.channels.UnsupportedAddressTypeException
		at java.base/sun.nio.ch.Net.checkAddress(Unknown Source)
		at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(Unknown Source)
		at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(Unknown Source)
		at org.apache.tomcat.util.net.NioEndpoint.initServerSocket(NioEndpoint.java:276)
		at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:231)
		at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1332)
		at org.apache.tomcat.util.net.AbstractEndpoint.init(AbstractEndpoint.java:1345)
		at org.apache.coyote.AbstractProtocol.init(AbstractProtocol.java:654)
		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1009)
		... 13 more
```

This error might be due to SCORM Engine being incompatible with IPv6 addresses such as `::1`. Setting `address="0.0.0.0"` will allow AJP to listen using IPv4 instead.

References:
- https://stackoverflow.com/questions/61186022/tomcat-ajp-8009-protocol-family-unavailable
- https://www.reddit.com/r/learnjava/comments/14i2vko/javaniochannelsunsupportedaddresstypeexception/
- https://tomcat.apache.org/tomcat-8.5-doc/config/ajp.html